### PR TITLE
Update Cargo.toml. Remove debug info from release build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,6 @@ opt-level = "s"
 [profile.release]
 panic = "abort"
 codegen-units = 1
-debug = true
 lto = true
 opt-level = "s"
 {%- comment %}


### PR DESCRIPTION
Debug information uses a lot of space for the binary file, which might result in simple binaries having bigger sizes than the Flash of the device.

In release mode, the program should be as compact as it can be in order to upload it to the microcontroller and use it as a final program/product.

If somebody needs the debug information that should be during developing and testing, for those situations, development profile should be used instead